### PR TITLE
add py.typed to package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setuptools.setup(
     },
     packages=setuptools.find_packages(where='src', exclude=['tests*']),
     package_dir={'': 'src'},
+    package_data={'smllib': ['py.typed']},
     classifiers=[
         "Development Status :: 4 - Beta",
         "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",


### PR DESCRIPTION
The py.typed file isn't automatically added to the wheel that's build during packaging/installation so it's never present in users python distributions. Add it via setuptools package_data facility.