### PR TITLE
Allows list entry with datatype SML_Time (#26)

### DIFF
--- a/src/smllib/sml/list_entry.py
+++ b/src/smllib/sml/list_entry.py
@@ -3,6 +3,7 @@ from typing import ClassVar, Dict, Optional, Union
 from smllib.const import OBIS_NAMES, UNITS
 from smllib.sml import SmlObjFieldInfo
 from smllib.sml._base_obj import INDENT, SmlBaseObj
+from smllib.sml.sml_value import build_sml_value
 
 from .sml_obis import ObisCode, build_obis
 from .sml_time import TIME_HINT, build_time
@@ -11,7 +12,8 @@ from .sml_time import TIME_HINT, build_time
 class SmlListEntry(SmlBaseObj):
     __sml__: ClassVar[Dict[str, SmlObjFieldInfo]] = {
         'val_time': SmlObjFieldInfo(func=build_time),
-        'obis': SmlObjFieldInfo(func=build_obis)
+        'obis': SmlObjFieldInfo(func=build_obis),
+        'value': SmlObjFieldInfo(func=build_sml_value),
     }
 
     obis: ObisCode
@@ -19,7 +21,7 @@ class SmlListEntry(SmlBaseObj):
     val_time: TIME_HINT
     unit: Optional[int]
     scaler: Optional[int]
-    value: Union[None, str, int, float]
+    value: Union[None, str, int, float, TIME_HINT]
     value_signature: Optional[str]
 
     def __repr__(self) -> str:

--- a/src/smllib/sml/sml_value.py
+++ b/src/smllib/sml/sml_value.py
@@ -1,0 +1,17 @@
+from smllib.errors import UnsupportedChoiceValue
+from smllib.sml.sml_time import build_time
+
+
+def build_sml_value(_in):
+    if _in is None:
+        return _in
+
+    if not isinstance(_in, list):
+        return _in
+
+    type_s, value_s = _in
+    _type = type_s.value
+    if _type == 1:  # SML_Time
+        return build_time(value_s.value)
+
+    raise UnsupportedChoiceValue(_type)

--- a/tests/builder/test_inspect.py
+++ b/tests/builder/test_inspect.py
@@ -10,7 +10,7 @@ from smllib.sml import (
     inspect_obj,
 )
 from smllib.sml.message import MSG_TYPES, SmlMessage
-from smllib.sml.sml_obis import build_obis, ObisCode
+from smllib.sml.sml_obis import ObisCode, build_obis
 from smllib.sml.sml_time import build_time
 from smllib.sml.sml_value import build_sml_value
 

--- a/tests/builder/test_inspect.py
+++ b/tests/builder/test_inspect.py
@@ -10,8 +10,9 @@ from smllib.sml import (
     inspect_obj,
 )
 from smllib.sml.message import MSG_TYPES, SmlMessage
-from smllib.sml.sml_obis import ObisCode, build_obis
+from smllib.sml.sml_obis import build_obis, ObisCode
 from smllib.sml.sml_time import build_time
+from smllib.sml.sml_value import build_sml_value
 
 
 def test_inspect_sml_message() -> None:
@@ -33,5 +34,5 @@ def test_inspect_sml_list_entry() -> None:
     assert fields['val_time'] == SmlObjFieldInfo(type=(type(None), int, datetime), func=build_time)
     assert fields['unit'] == SmlObjFieldInfo(type=(int, type(None)))
     assert fields['scaler'] == SmlObjFieldInfo(type=(int, type(None)))
-    assert fields['value'] == SmlObjFieldInfo(type=(type(None), str, int, float))
+    assert fields['value'] == SmlObjFieldInfo(type=(type(None), str, int, float, datetime), func=build_sml_value)
     assert fields['value_signature'] == SmlObjFieldInfo(type=(str, type(None)))

--- a/tests/sml/test_value.py
+++ b/tests/sml/test_value.py
@@ -1,0 +1,19 @@
+from datetime import datetime
+
+import pytest
+
+from tests.helper import in_snip
+from smllib.errors import UnsupportedChoiceValue
+from smllib.sml.sml_value import build_sml_value
+
+
+def test_sml_value():
+    assert build_sml_value(None) is None
+    assert build_sml_value(12) == 12
+    assert build_sml_value(in_snip([1, [2, 1609466461]], pack_top=False)) == datetime(2021, 1, 1, 2, 1, 1)
+
+def test_sml_value_with_unsupported_choice():
+    with pytest.raises(UnsupportedChoiceValue) as e:
+        build_sml_value(in_snip([2, 3], pack_top=False))
+    assert e.value.type == 2
+    assert str(e.value) == 'Unsupported type 0x02'

--- a/tests/sml/test_value.py
+++ b/tests/sml/test_value.py
@@ -1,18 +1,18 @@
 from datetime import datetime
 
 import pytest
-
 from tests.helper import in_snip
+
 from smllib.errors import UnsupportedChoiceValue
 from smllib.sml.sml_value import build_sml_value
 
 
-def test_sml_value():
+def test_sml_value() -> None:
     assert build_sml_value(None) is None
     assert build_sml_value(12) == 12
     assert build_sml_value(in_snip([1, [2, 1609466461]], pack_top=False)) == datetime(2021, 1, 1, 2, 1, 1)
 
-def test_sml_value_with_unsupported_choice():
+def test_sml_value_with_unsupported_choice() -> None:
     with pytest.raises(UnsupportedChoiceValue) as e:
         build_sml_value(in_snip([2, 3], pack_top=False))
     assert e.value.type == 2

--- a/tests/test_sml_fields.py
+++ b/tests/test_sml_fields.py
@@ -1,4 +1,5 @@
 from binascii import a2b_hex
+from datetime import datetime
 
 from smllib.builder import SmlListEntryBuilder, create_context
 from smllib.sml_frame import SmlFrame
@@ -36,3 +37,14 @@ def test_val_time() -> None:
     val_list = f._parse_msg(f.get_value(0))
     o = SmlListEntryBuilder().build(val_list, create_context())
     assert o.val_time == 0
+
+def test_value_sml_time():
+    f = SmlFrame(a2b_hex('770781006008000101010101726201726202655FEE825D01'))
+    val_list = f._parse_msg(f.get_value(0))
+    o = SmlListEntryBuilder().build(val_list, create_context())
+
+    assert o.obis == '810060080001'
+    assert o.status == None
+    assert o.unit == None
+    assert o.scaler == None
+    assert o.value == datetime(2021, 1, 1, 2, 1, 1)

--- a/tests/test_sml_fields.py
+++ b/tests/test_sml_fields.py
@@ -38,7 +38,7 @@ def test_val_time() -> None:
     o = SmlListEntryBuilder().build(val_list, create_context())
     assert o.val_time == 0
 
-def test_value_sml_time():
+def test_value_sml_time() -> None:
     f = SmlFrame(a2b_hex('770781006008000101010101726201726202655FEE825D01'))
     val_list = f._parse_msg(f.get_value(0))
     o = SmlListEntryBuilder().build(val_list, create_context())


### PR DESCRIPTION
According to the [SML specification](https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR03109/TR-03109-1_Anlage_Feinspezifikation_Drahtgebundene_LMN-Schnittstelle_Teilb.pdf?__blob=publicationFile&v=1#p=27), the `SML_Value` data type also allows the CHOICE type `SML_ListType`, which can be used to transmit timestamps (i.e. `SML_Time`). Frames containing such values are currently not supported by the library (see #26).

With this pull request, the input is now parsed as `SML_ListType` if it is a list. Otherwise, everything remains unchanged.